### PR TITLE
docs: add notes env preparation using gcp and pyenv

### DIFF
--- a/01-intro/README.md
+++ b/01-intro/README.md
@@ -150,4 +150,5 @@ Did you take notes? Add them here:
 * [Environment Setup by Ayoub](https://github.com/ayoub-berdeddouch/mlops-journey/blob/main/intro-01.md)
 * [Intro, Environment Setup, and MLOps Maturity Models by Bala](https://github.com/balapriyac/DTC-MLOps-Zoomcamp/tree/main/week1)
 * [GCP Environment Setup by Piyush](https://github.com/piyush-an/MLOps-ZoomCamp/blob/main/01-Introduction/infrastructure.md)
+* [Environment Preparation using GCP and pyenv by Dani](https://github.com/syahrulhamdani/dtc-mlops/blob/main/week-1-introduction/README.md)
 * Send a PR, add your notes above this line


### PR DESCRIPTION
Add notes on environment preparation using GCP (instead of AWS) and pyenv (instead of Anaconda).