### PR TITLE
Fix missing type in parser

### DIFF
--- a/02-experiment-tracking/homework/register_model.py
+++ b/02-experiment-tracking/homework/register_model.py
@@ -82,6 +82,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--top_n",
         default=5,
+        type=int,
         help="the top 'top_n' models will be evaluated to decide which model to promote."
     )
     args = parser.parse_args()


### PR DESCRIPTION
This PR fixes a bug when you provide a custom value for `--top_n`.
Example:

```
python register_model.py --data_path ../../data --top_n 10
```

argparse doesn't cast value `"10"` to int automatically, so when we access MLFlow client search API we have the following error:

```
Traceback (most recent call last):
  File "/code/mlops-zoomcamp/02-experiment-tracking/homework/register_model.py", line 96, in <module>
    run(args.data_path, args.top_n)
  File "/code/mlops-zoomcamp/02-experiment-tracking/homework/register_model_final.py", line 57, in run
    runs = client.search_runs(
  File "envs/mlops/lib/python3.10/site-packages/mlflow/tracking/client.py", line 1610, in search_runs
    return self._tracking_client.search_runs(
  File "envs/mlops/lib/python3.10/site-packages/mlflow/tracking/_tracking_service/client.py", line 429, in search_runs
    return self.store.search_runs(
  File "envs/mlops/lib/python3.10/site-packages/mlflow/store/tracking/abstract_store.py", line 242, in search_runs
    runs, token = self._search_runs(
  File "envs/mlops/lib/python3.10/site-packages/mlflow/store/tracking/rest_store.py", line 257, in _search_runs
    sr = SearchRuns(
TypeError: '10' has type str, but expected one of: int
```