### PR TITLE
Added Link to Homework folder

### DIFF
--- a/02-experiment-tracking/homework.md
+++ b/02-experiment-tracking/homework.md
@@ -20,7 +20,7 @@ We'll use the same dataset used in the videos of the 1st and 2nd module: "Green 
 
 Download the data for January, February and March 2021 in parquet format from [here](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page).
 
-Use the script `preprocess_data.py` located in the folder [`homework`](https://github.com/MekongDelta-mind/mlops-zoomcamp/tree/main/02-experiment-tracking/homework) to preprocess the data.
+Use the script `preprocess_data.py` located in the folder [`homework`](https://github.com/DataTalksClub/mlops-zoomcamp/tree/main/02-experiment-tracking/homework) to preprocess the data.
 
 The script will
 

--- a/02-experiment-tracking/homework.md
+++ b/02-experiment-tracking/homework.md
@@ -20,7 +20,7 @@ We'll use the same dataset used in the videos of the 1st and 2nd module: "Green 
 
 Download the data for January, February and March 2021 in parquet format from [here](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page).
 
-Use the script `preprocess_data.py` located in the folder `homework` to preprocess the data.
+Use the script `preprocess_data.py` located in the folder [`homework`](https://github.com/MekongDelta-mind/mlops-zoomcamp/tree/main/02-experiment-tracking/homework) to preprocess the data.
 
 The script will
 


### PR DESCRIPTION
Commit 1: 
Adding the link to the homework folder for easy accessibility. 
I took some time to search around the repo where to find the home folder. As this is the first mention of the homework folder in the entire Doc. That is the reason it is necessary only at the mentioned line

Commit 2: 
The homework link in the line 23 was linked to my own repo (Mekong-delta). Changed it to the link of the DataTalks course's homework folder .