### PR TITLE
fix type of argument --max_evals

### DIFF
--- a/02-experiment-tracking/homework/hpo.py
+++ b/02-experiment-tracking/homework/hpo.py
@@ -61,6 +61,7 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         "--max_evals",
+        type=int,
         default=50,
         help="the number of parameter evaluations for the optimizer to explore."
     )


### PR DESCRIPTION
The default type for `parser.add_argument()` ist string.  When the argument is parsed, the variable `max_evals` contains a string value, which will result in an TypeError in line 48. The passed value should be parsed to integer, therefore `type=int` should be added to `parser.add_argument()`.