### PR TITLE
Grafana could not read Prometheus data

### DIFF
--- a/05-monitoring/docker-compose.yml
+++ b/05-monitoring/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
     ports:
-      - "9091:9090"
+      - "9090:9090"
     networks:
       - back-tier
     restart: always


### PR DESCRIPTION
The only way I could grafana read the data from Prometheus was changing the number of the grafana port. I am using WSL on windows 10 with chrome. 