### PR TITLE
Correcting artifact path to train.py

### DIFF
--- a/cohorts/2023/02-experiment-tracking/wandb.md
+++ b/cohorts/2023/02-experiment-tracking/wandb.md
@@ -79,7 +79,7 @@ You can run the script using:
 python train.py \
   --wandb_project <WANDB_PROJECT_NAME> \
   --wandb_entity <WANDB_USERNAME> \
-  --data_artifact "<WANDB_USERNAME><WANDB_PROJECT_NAME>//NYC-Taxi:v0"
+  --data_artifact "<WANDB_USERNAME>/<WANDB_PROJECT_NAME>/NYC-Taxi:v0"
 ```
 
 Tip 1: You can find the artifact address under the `Usage` tab in the respective artifact's page.


### PR DESCRIPTION
The artifact fact in the HW  was provided as `--data_artifact "<WANDB_PROJECT_NAME>/<WANDB_USERNAME>/NYC-Taxi:v0"`

This PR corrects it to `--data_artifact "<WANDB_USERNAME>/<WANDB_PROJECT_NAME>/NYC-Taxi:v0"`