### PR TITLE
fix: markdown artifact formatting error

### DIFF
--- a/03-orchestration/3.5/orchestrate_s3.py
+++ b/03-orchestration/3.5/orchestrate_s3.py
@@ -112,16 +112,16 @@ def train_best_model(
 
         markdown__rmse_report = f"""# RMSE Report
 
-        ## Summary
+## Summary
 
-        Duration Prediction 
+Duration Prediction 
 
-        ## RMSE XGBoost Model
+## RMSE XGBoost Model
 
-        | Region    | RMSE |
-        |:----------|-------:|
-        | {date.today()} | {rmse:.2f} |
-        """
+| Region    | RMSE |
+|:----------|-------:|
+| {date.today()} | {rmse:.2f} |
+"""
 
         create_markdown_artifact(
             key="duration-model-report", markdown=markdown__rmse_report


### PR DESCRIPTION
Quite a minor formatting issue, but wanted to share nonetheless.

In the video [MLOps Zoomcamp 3.5 - Working with Deployments](https://youtu.be/jVmaaqs63O8?t=1431) Jeff shows what needs to be done to create a markdown artifact as part of a deployment run. 

The output (also shown in the video) is not formatted correctly: 
![image](https://github.com/DataTalksClub/mlops-zoomcamp/assets/33279480/4e5750bb-e184-49a9-b584-b01014cc8887)

Looking at the [prefect docs](https://docs.prefect.io/2.10.13/concepts/artifacts/#creating-markdown-artifacts) the indentation is removed/fully dedented. Doing this as seen in the proposed change it is then formatted correctly:
![image](https://github.com/DataTalksClub/mlops-zoomcamp/assets/33279480/05153824-f941-4f63-9e89-5812260c7856)
