### PR TITLE
include matplotlib in requirements

### DIFF
--- a/05-monitoring/requirements.txt
+++ b/05-monitoring/requirements.txt
@@ -10,3 +10,4 @@ pandas
 numpy
 scikit-learn
 jupyter
+matplotlib


### PR DESCRIPTION
when running the baseline_model_nyc_taxi_data.ipynb inside the venv i got an error for missing matplotlib. installing it inside the venv solved the issue. i propose to include the matplotlib in the requirements.txt