### PR TITLE
Add link to deadline calendar to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Our MLOps Zoomcamp course
 * **Registration link**: https://airtable.com/shrCb8y6eTbPKwSTL
 * Subscribe to our [public Google Calendar](https://calendar.google.com/calendar/?cid=M3Jzbmg0ZDA2aHVsY2M1ZjcyNDJtODNyMTRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) (it works from Desktop only)
 * [Cohort folder](cohorts/2023)
+* **Deadline Callendar** for [2023 Cohort](https://docs.google.com/spreadsheets/d/e/2PACX-1vRNTwA0Of1lyprYpn2YxU-l0gvNeq-up7g7ITB42nPf2gT9Qd3PTzqTmkjAZjk1s__r7D99CsJfcZEO/pubhtml?gid=0&single=true)
 
 ### Self-paced mode
 


### PR DESCRIPTION
It's better for visibility to have the deadline calendar in a place where it's easy to find and access.