### PR TITLE
Week 1 exercise is vague in its description of one hot encoding

### DIFF
--- a/cohorts/2023/01-intro/homework.md
+++ b/cohorts/2023/01-intro/homework.md
@@ -46,7 +46,8 @@ What fraction of the records left after you dropped the outliers?
 
 Let's apply one-hot encoding to the pickup and dropoff location IDs. We'll use only these two features for our model. 
 
-* Turn the dataframe into a list of dictionaries
+* Turn the dataframe into a list of dictionaries (remember to re-cast the ids to strings - otherwise it will 
+  label encode them)
 * Fit a dictionary vectorizer 
 * Get a feature matrix from it
 


### PR DESCRIPTION
Clarified that the ids, which are ints, needs to be re-cast to strinsg if we want actual one hot encoding, otherwise they will be label encoded

All the code would still run, but the RMSE would be (very) different. That cost me half an hour before I saw the notebook with your solution.