### PR TITLE
Fixes problems with passing parameters week 2

### DIFF
--- a/cohorts/2024/02-experiment-tracking/homework/register_model.py
+++ b/cohorts/2024/02-experiment-tracking/homework/register_model.py
@@ -28,10 +28,11 @@ def train_and_log_model(data_path, params):
     X_test, y_test = load_pickle(os.path.join(data_path, "test.pkl"))
 
     with mlflow.start_run():
+        new_params = {}
         for param in RF_PARAMS:
-            params[param] = int(params[param])
+            new_params[param] = int(params[param])
 
-        rf = RandomForestRegressor(**params)
+        rf = RandomForestRegressor(**new_params)
         rf.fit(X_train, y_train)
 
         # Evaluate model on the validation and test sets


### PR DESCRIPTION
Based on the problem - https://datatalks-club.slack.com/archives/C02R98X7DS9/p1685203191371579

When used without any modifications register_model crashes with: 
`sklearn.utils._param_validation.InvalidParameterError: The 'bootstrap' parameter of RandomForestRegressor must be an instance of 'bool' or an instance of 'numpy.bool_'. Got 'True' instead.`

And as was stated in the thread - there are more broken parameters being passed, which denies ability to just fix for this specific bool conversion('ccp_alpha','max_features', etc)

Current change definetely works and fixes the problem - but if there are more elegant ways to fix it - I`m all ears. 

Credit goes to Shubhdeep Singh in the slack thread.