### PR TITLE
update instructions to install docker and docker compose on ubuntu be…

### DIFF
--- a/01-intro/README.md
+++ b/01-intro/README.md
@@ -47,10 +47,8 @@ sudo apt update
 ```
 
 ### Step 3: Install Docker
-
-```sh
-sudo apt install docker.io
-```
+Follow the instructions here:
+[install-using-the-repository](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)
 
 To run docker without `sudo`:
 
@@ -59,54 +57,14 @@ sudo groupadd docker
 sudo usermod -aG docker $USER
 ```
 
-### Step 4: Install Docker Compose
-
-Install docker-compose in a separate directory
-
-```sh
-mkdir soft
-cd soft
-```
-
-To get the latest release of Docker Compose, go to https://github.com/docker/compose and download the release for your OS.
-
-```sh
-wget https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-x86_64 -O docker-compose
-```
-
-Make it executable
-
-```sh
-chmod +x docker-compose
-```
-
-Add to the `soft` directory to `PATH`. Open the `.bashrc` file with `nano`:
-
-```sh
-nano ~/.bashrc
-```
-
-In `.bashrc`, add the following line:
-
-```bash
-export PATH="${HOME}/soft:${PATH}"
-```
-
-Save it and run the following to make sure the changes are applied:
-
-```bash
-source ~/.bashrc
-```
-
-
-### Step 5: Run Docker
+### Step 4: Run Docker
 
 ```sh
 docker run hello-world
 ```
 
-If you get `docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/create": dial unix /var/run/docker.sock: connect: permission denied.` error, restart your VM instance. 
-
+If you get `docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/create": dial unix /var/run/docker.sock: connect: permission denied.` error, restart your VM instance, or run:
+`sudo dockerd`
 
 **Note**: If you get `It is required that your private key files are NOT accessible by others. This private key will be ignored.` error, you should change permits on the downloaded file to protect your private key:
 

--- a/01-intro/README.md
+++ b/01-intro/README.md
@@ -46,10 +46,29 @@ bash Anaconda3-2022.05-Linux-x86_64.sh
 sudo apt update
 ```
 
-### Step 3: Install Docker
+### Step 3: Install Docker and Docker Compose
 Follow the instructions here:
-[install-using-the-repository](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)
+[install-using-the-repository](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)  
+Set up Docker's apt repository.
+```sh
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
 
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+```
+Install the Docker packages.
+```sh
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
 To run docker without `sudo`:
 
 ```sh


### PR DESCRIPTION
Updated instructions to install docker and docker compose on ubuntu,
because current instructions refer to the deprecated docker compose v1.
Tested in an AWS EC2, works fine.