### PR TITLE
Update grafana_datasources.yaml

### DIFF
--- a/05-monitoring/config/grafana_datasources.yaml
+++ b/05-monitoring/config/grafana_datasources.yaml
@@ -7,10 +7,11 @@ datasources:
   - name: PostgreSQL
     type: postgres
     access: proxy
-    url: db.:5432
+    url: db:5432
     database: test
     user: postgres
     secureJsonData:
       password: 'example'
     jsonData:
       sslmode: 'disable'
+      database: test


### PR DESCRIPTION
updated yaml file so that the test db with the dummy_metrics table can be visible on grafana as per 5.4