### PR TITLE
Fix homework link to year 2024

### DIFF
--- a/06-best-practices/README.md
+++ b/06-best-practices/README.md
@@ -48,7 +48,7 @@
 
 ### 6.7 Homework
 
-More information [here](../cohorts/2023/06-best-practices/homework.md).
+More information [here](../cohorts/2024/06-best-practices/homework.md).
 
 
 ### Notes


### PR DESCRIPTION
Looks like the module had outdated link to the homework of year 2023 