### PR TITLE
Use `root_mean_squared_error` instead of `mean_squared_error`

### DIFF
--- a/01-intro/duration-prediction.ipynb
+++ b/01-intro/duration-prediction.ipynb
@@ -61,7 +61,7 @@
     "from sklearn.linear_model import Lasso\n",
     "from sklearn.linear_model import Ridge\n",
     "\n",
-    "from sklearn.metrics import mean_squared_error"
+    "from sklearn.metrics import root_mean_squared_error"
    ]
   },
   {
@@ -115,7 +115,7 @@
     "\n",
     "y_pred = lr.predict(X_train)\n",
     "\n",
-    "mean_squared_error(y_train, y_pred, squared=False)"
+    "root_mean_squared_error(y_train, y_pred)"
    ]
   },
   {
@@ -288,7 +288,7 @@
     "\n",
     "y_pred = lr.predict(X_val)\n",
     "\n",
-    "mean_squared_error(y_val, y_pred, squared=False)"
+    "root_mean_squared_error(y_val, y_pred)"
    ]
   },
   {
@@ -325,7 +325,7 @@
     "\n",
     "y_pred = lr.predict(X_val)\n",
     "\n",
-    "mean_squared_error(y_val, y_pred, squared=False)"
+    "root_mean_squared_error(y_val, y_pred)"
    ]
   },
   {


### PR DESCRIPTION
The 'squared' arg is deprecated in version 1.4 and will be removed in 1.6. To calculate the root mean squared error, use the function'root_mean_squared_error'.