### PR TITLE
Updated grafana image to fix issue raised in #319

### DIFF
--- a/05-monitoring/docker-compose.yml
+++ b/05-monitoring/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - front-tier  
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana-enterprise
     user: "472"
     ports:
       - "3000:3000"


### PR DESCRIPTION
As per issue #319 , there is an update to way the grafana image can be used, we need to switch to grafana enterprise. This fix is to address that, tested locally