### PR TITLE
Update scenario-2.ipynb

### DIFF
--- a/02-experiment-tracking/running-mlflow-examples/scenario-2.ipynb
+++ b/02-experiment-tracking/running-mlflow-examples/scenario-2.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mlflow.list_experiments()"
+    "mlflow.search_experiments()"
    ]
   },
   {
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mlflow.list_experiments()"
+    "mlflow.search_experiments()"
    ]
   },
   {
@@ -110,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.list_registered_models()"
+    "client.search_registered_models()"
    ]
   },
   {
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_id = client.list_run_infos(experiment_id='1')[0].run_id\n",
+    "run_id = client.search_runs(experiment_ids='1')[0].info.run_id\n",
     "mlflow.register_model(\n",
     "    model_uri=f\"runs:/{run_id}/models\",\n",
     "    name='iris-classifier'\n",


### PR DESCRIPTION
- `list_experiments` was changed to `search_experiments`
- `list_registered_models` was changed to `search_registered_models`

- `client.list_run_infos(experiment_id='1')[0].run_id` needs to be changed to `client.search_runs(experiment_ids='1')[0].info.run_id` as `list_run_infos` became `search_runs` and the `run_id` is now inside `info.run_id`