### PR TITLE
change mse for rmse

### DIFF
--- a/cohorts/2025/02-experiment-tracking/homework/train.py
+++ b/cohorts/2025/02-experiment-tracking/homework/train.py
@@ -3,7 +3,7 @@ import pickle
 import click
 
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.metrics import mean_squared_error
+from sklearn.metrics import root_mean_squared_error
 
 
 def load_pickle(filename: str):
@@ -26,7 +26,7 @@ def run_train(data_path: str):
     rf.fit(X_train, y_train)
     y_pred = rf.predict(X_val)
 
-    rmse = mean_squared_error(y_val, y_pred, squared=False)
+    rmse = root_mean_squared_error(y_val, y_pred)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The most recent version of sklearn use the function root_mean_squared_error instead of using mean_squared_error without the parameter of squared=False

https://scikit-learn.org/stable/modules/generated/sklearn.metrics.root_mean_squared_error.html

I changed the code to be compatible to the most recent version of sklearn