### PR TITLE
Update column names to match the 2023 Yellow Taxi dataset format

### DIFF
--- a/cohorts/2025/02-experiment-tracking/homework/preprocess_data.py
+++ b/cohorts/2025/02-experiment-tracking/homework/preprocess_data.py
@@ -14,7 +14,7 @@ def dump_pickle(obj, filename: str):
 def read_dataframe(filename: str):
     df = pd.read_parquet(filename)
 
-    df['duration'] = df['lpep_dropoff_datetime'] - df['lpep_pickup_datetime']
+    df['duration'] = df['tpep_dropoff_datetime'] - df['tpep_pickup_datetime']
     df.duration = df.duration.apply(lambda td: td.total_seconds() / 60)
     df = df[(df.duration >= 1) & (df.duration <= 60)]
 
@@ -45,7 +45,7 @@ def preprocess(df: pd.DataFrame, dv: DictVectorizer, fit_dv: bool = False):
     "--dest_path",
     help="Location where the resulting files will be saved"
 )
-def run_data_prep(raw_data_path: str, dest_path: str, dataset: str = "green"):
+def run_data_prep(raw_data_path: str, dest_path: str, dataset: str = "yellow"):
     # Load parquet files
     df_train = read_dataframe(
         os.path.join(raw_data_path, f"{dataset}_tripdata_2023-01.parquet")


### PR DESCRIPTION
While running `cohorts/2025/02-experiment-tracking/homework/preprocess_data.py`, I encountered the error, 

```bash
$ python homework/preprocess_data.py --raw_data_path . --dest_path dest/
Traceback (most recent call last):
  File "C:\Users\rgk\miniconda3\envs\mlflow\lib\site-packages\pandas\core\indexes\base.py", line 3805, in get_loc
    return self._engine.get_loc(casted_key)
  File "index.pyx", line 167, in pandas._libs.index.IndexEngine.get_loc
  File "index.pyx", line 196, in pandas._libs.index.IndexEngine.get_loc
  File "pandas\\_libs\\hashtable_class_helper.pxi", line 7081, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas\\_libs\\hashtable_class_helper.pxi", line 7089, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "C:\Users\rgk\miniconda3\envs\mlflow\lib\site-packages\click\core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\rgk\miniconda3\envs\mlflow\lib\site-packages\click\core.py", line 788, in invoke
  File "C:\Users\rgk\miniconda3\envs\mlflow\lib\site-packages\click\core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\rgk\miniconda3\envs\mlflow\lib\site-packages\click\core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "E:\mlops-zoomcamp\homework-2\homework\preprocess_data.py", line 50, in run_data_prep
    df_train = read_dataframe(
  File "E:\mlops-zoomcamp\homework-2\homework\preprocess_data.py", line 17, in read_dataframe
    df['duration'] = df['lpep_dropoff_datetime'] - df['lpep_pickup_datetime']
  File "C:\Users\rgk\miniconda3\envs\mlflow\lib\site-packages\pandas\core\frame.py", line 4102, in __getitem__
    indexer = self.columns.get_loc(key)
  File "C:\Users\rgk\miniconda3\envs\mlflow\lib\site-packages\pandas\core\indexes\base.py", line 3812, in get_loc
    raise KeyError(key) from err
KeyError: 'lpep_dropoff_datetime'
```

and upon executing `pd.read_parquet('./yellow_tripdata_2023-01.parquet').columns`, I got

```python
Out[31]:
Index(['VendorID', 'tpep_pickup_datetime', 'tpep_dropoff_datetime',
       'passenger_count', 'trip_distance', 'RatecodeID', 'store_and_fwd_flag',
       'PULocationID', 'DOLocationID', 'payment_type', 'fare_amount', 'extra',
       'mta_tax', 'tip_amount', 'tolls_amount', 'improvement_surcharge',
       'total_amount', 'congestion_surcharge', 'airport_fee'],
      dtype='object')
```

I could see, there's no `lpep_dropoff_datetime` column in the yellow taxi datasets, it is in green taxi datasets. Changing the column names to `tpep_dropoff_datetime` and `tpep_pickup_datetime` fixed the issue. Also, this PR changed the default dataset type to `'yellow'` as well.