### PR TITLE
fix: correct if condition and replace deprecated set-output in cd-deploy.yml

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -32,13 +32,13 @@ jobs:
       - name: TF Apply
         id: tf-apply
         working-directory: '06-best-practices/code/infrastructure'
-        if: ${{ steps.tf-plan.outcome }} == 'success'
+        if: ${{ steps.tf-plan.outcome == 'success' }}
         run: |
           terraform apply -auto-approve -var-file=vars/prod.tfvars
-          echo "::set-output name=ecr_repo::$(terraform output ecr_repo | xargs)"
-          echo "::set-output name=predictions_stream_name::$(terraform output predictions_stream_name | xargs)"
-          echo "::set-output name=model_bucket::$(terraform output model_bucket | xargs)"
-          echo "::set-output name=lambda_function::$(terraform output lambda_function | xargs)"
+          echo "ecr_repo=$(terraform output -raw ecr_repo)" >> $GITHUB_OUTPUT
+          echo "predictions_stream_name=$(terraform output -raw predictions_stream_name)" >> $GITHUB_OUTPUT
+          echo "model_bucket=$(terraform output -raw model_bucket)" >> $GITHUB_OUTPUT
+          echo "lambda_function=$(terraform output -raw lambda_function)" >> $GITHUB_OUTPUT
 
       # Build-Push
       - name: Login to Amazon ECR
@@ -55,7 +55,7 @@ jobs:
         run: |
           docker build -t ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG} .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "::set-output name=image_uri::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          echo "image_uri=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       # Deploy
       - name: Get model artifacts
@@ -73,7 +73,7 @@ jobs:
           export RUN_ID=$(aws s3api list-objects-v2 --bucket ${MODEL_BUCKET_DEV} \
           --query 'sort_by(Contents, &LastModified)[-1].Key' --output=text | cut -f2 -d/)
           aws s3 sync s3://${MODEL_BUCKET_DEV} s3://${MODEL_BUCKET_PROD}
-          echo "::set-output name=run_id::${RUN_ID}"
+          echo "run_id=${RUN_ID}" >> $GITHUB_OUTPUT
 
       - name: Update Lambda
         env:


### PR DESCRIPTION
## Problem

Two bugs in `.github/workflows/cd-deploy.yml`:

### 1. Broken `if` condition on TF Apply step (line 35)

**Before:**
```yaml
if: ${{ steps.tf-plan.outcome }} == 'success'
```

**After:**
```yaml
if: ${{ steps.tf-plan.outcome == 'success' }}
```

The original expression evaluates `${{ steps.tf-plan.outcome }}` to the string `'success'`, then compares `'success' == 'success'` as a literal string *outside* the expression context — which always evaluates to `true`. The TF Apply step would therefore run even when TF plan fails.

### 2. Deprecated `::set-output` command (4 occurrences)

The `::set-output name=KEY::VALUE` syntax was deprecated and later removed in GitHub Actions runner 2.298.2. All four occurrences have been replaced with the current syntax:

```yaml
echo "KEY=VALUE" >> $GITHUB_OUTPUT
```

Also switched `terraform output` → `terraform output -raw` to avoid the deprecation warning about quotes in the output.

Fixes #396