### PR TITLE
Add SITE.md for the website course description

### DIFF
--- a/SITE.md
+++ b/SITE.md
@@ -1,0 +1,5 @@
+# MLOps Zoomcamp
+
+MLOps Zoomcamp is a completely free, hands-on course on productionizing machine learning services, from training and experimentation through to deployment and monitoring.
+
+Six modules cover experiment tracking and model management with MLflow, workflow orchestration and ML pipelines, online and batch model deployment, model monitoring, and engineering best practices such as testing, CI/CD, and infrastructure as code. A final project ties them together into an end-to-end system. All materials are available for self-paced study.


### PR DESCRIPTION
Adds `SITE.md`, a short course description written for the DataTalks.Club website.

**Why:** the website takes this course's description from the repository. Today it reads `README.md`, which is written for a GitHub audience, so the website ends up rendering badges, centered HTML and contributor lists. `SITE.md` gives the website a file whose only job is to be that copy.

**Notes**

- `README.md` is unchanged. Nothing else in the repository changes.
- This repository has no `course.yaml`, so there is currently no `description_path` to repoint. The website side has to be pointed at `SITE.md` separately.
- The copy is condensed from the existing DataTalks.Club course page for this course in `DataTalksClub/docs` (`courses/mlops-zoomcamp/`). It is a shortened version of authored copy rather than new marketing text, but it is worth an owner read before merging.
